### PR TITLE
Cg 218

### DIFF
--- a/app/components/buttons/registration-button/registration-button.tsx
+++ b/app/components/buttons/registration-button/registration-button.tsx
@@ -19,8 +19,6 @@ export const RegistrationButton = (props: RegistrationButtonProps, { children })
   const inactiveStyle: StyleProp<TextStyle> = {
     borderColor: LIGHT_LINE,
     borderWidth: 2,
-    // ? 활성화 상태일 때는 적용 X -> X버튼에 paddingVertical이 들어가기 때문
-    paddingVertical: 8,
   }
   // * 활성화 | 비활성화 상태에 따라서 스타일을 다르게 지정
   const buttonStyle = isActive ? activeStyle : inactiveStyle
@@ -28,10 +26,10 @@ export const RegistrationButton = (props: RegistrationButtonProps, { children })
   return (
     // ? 버튼이 선택되지 않았을 때만 onPress 지정 (onPress -> 옵션을 '선택된 옵션' 배열에 추가하는 작업을 시행)
     <Pressable onPress={!isActive ? onPress : null} style={[styles.root, style, buttonStyle]}>
-      <PreReg14 text={text} color={isActive ? color.palette.white : DISABLED} />
+      <PreReg14 text={text} style={styles.text} color={isActive ? color.palette.white : DISABLED} />
       {isActive && (
         <Pressable style={styles.x_container} onPress={onXPress}>
-          <Image source={images.x_white} style={styles.x_img} />
+          <Image source={images.x_white} defaultSource={images.x_white} style={styles.x_img} />
         </Pressable>
       )}
     </Pressable>

--- a/app/components/buttons/registration-button/registration-button.tsx
+++ b/app/components/buttons/registration-button/registration-button.tsx
@@ -29,9 +29,11 @@ export const RegistrationButton = (props: RegistrationButtonProps, { children })
     // ? 버튼이 선택되지 않았을 때만 onPress 지정 (onPress -> 옵션을 '선택된 옵션' 배열에 추가하는 작업을 시행)
     <Pressable onPress={!isActive ? onPress : null} style={[styles.root, style, buttonStyle]}>
       <PreReg14 text={text} color={isActive ? color.palette.white : DISABLED} />
-      <Pressable style={styles.x_container} onPress={isActive ? onXPress : null}>
-        {isActive && <Image source={images.x_white} style={styles.x_img} />}
-      </Pressable>
+      {isActive && (
+        <Pressable style={styles.x_container} onPress={onXPress}>
+          <Image source={images.x_white} style={styles.x_img} />
+        </Pressable>
+      )}
     </Pressable>
   )
 }

--- a/app/components/buttons/registration-button/registration-button.tsx
+++ b/app/components/buttons/registration-button/registration-button.tsx
@@ -16,7 +16,12 @@ export const RegistrationButton = (props: RegistrationButtonProps, { children })
     backgroundColor: GIVER_CASUAL_NAVY,
   }
   // * 버튼이 비활성화 상태일 때 적용되는 스타일
-  const inactiveStyle: StyleProp<TextStyle> = { borderColor: LIGHT_LINE, borderWidth: 2 }
+  const inactiveStyle: StyleProp<TextStyle> = {
+    borderColor: LIGHT_LINE,
+    borderWidth: 2,
+    // ? 활성화 상태일 때는 적용 X -> X버튼에 paddingVertical이 들어가기 때문
+    paddingVertical: 8,
+  }
   // * 활성화 | 비활성화 상태에 따라서 스타일을 다르게 지정
   const buttonStyle = isActive ? activeStyle : inactiveStyle
 
@@ -24,11 +29,9 @@ export const RegistrationButton = (props: RegistrationButtonProps, { children })
     // ? 버튼이 선택되지 않았을 때만 onPress 지정 (onPress -> 옵션을 '선택된 옵션' 배열에 추가하는 작업을 시행)
     <Pressable onPress={!isActive ? onPress : null} style={[styles.root, style, buttonStyle]}>
       <PreReg14 text={text} color={isActive ? color.palette.white : DISABLED} />
-      {isActive && (
-        <Pressable style={styles.x_container} onPress={onXPress}>
-          <Image source={images.x_white} style={styles.x_img} />
-        </Pressable>
-      )}
+      <Pressable style={styles.x_container} onPress={isActive ? onXPress : null}>
+        {isActive && <Image source={images.x_white} style={styles.x_img} />}
+      </Pressable>
     </Pressable>
   )
 }

--- a/app/components/buttons/registration-button/styles.ts
+++ b/app/components/buttons/registration-button/styles.ts
@@ -14,9 +14,15 @@ export const styles = StyleSheet.create({
     paddingRight: 0,
   },
 
+  text: {
+    paddingVertical: 8,
+  },
+
   x_container: {
+    height: "100%",
     paddingHorizontal: 16,
-    paddingVertical: 14,
+    flexDirection: "row",
+    alignItems: "center",
   },
 
   x_img: {

--- a/app/components/buttons/registration-button/styles.ts
+++ b/app/components/buttons/registration-button/styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from "react-native"
 
 export const styles = StyleSheet.create({
   root: {
-    paddingVertical: 8,
+    // paddingVertical: 8,
     paddingHorizontal: 16,
 
     borderRadius: 4,
@@ -16,6 +16,7 @@ export const styles = StyleSheet.create({
 
   x_container: {
     paddingHorizontal: 16,
+    paddingVertical: 14,
   },
 
   x_img: {

--- a/app/screens/registration-stack/service-registration-screen/service-registration-screen.tsx
+++ b/app/screens/registration-stack/service-registration-screen/service-registration-screen.tsx
@@ -1,4 +1,4 @@
-import { FlatList, TextStyle, View, StyleProp } from "react-native"
+import { FlatList, TextStyle, View, StyleProp, useWindowDimensions } from "react-native"
 import React, { useCallback, useEffect, useLayoutEffect, FC, useState } from "react"
 import { StackScreenProps } from "@react-navigation/stack"
 import { NavigatorParamList } from "#navigators"
@@ -9,9 +9,10 @@ import {
   ScreenRootView,
   PressableButton,
   PreBol16,
+  BASIC_BACKGROUND_PADDING_WIDTH,
 } from "#components"
 import { styles } from "./styles"
-import { color, HEIGHT } from "#theme"
+import { color } from "#theme"
 // * 화면에 띄울 서비스 배열
 import { services } from "./service-data"
 
@@ -57,8 +58,16 @@ export const ServiceRegistrationScreen: FC<
     alert("제출 버튼 클릭")
   }
 
-  // * 옵션 버튼을 담는 컨테이너의 너비 (flatlist의 너비 값을 저장)
-  const [containerWidth, setContainerWidth] = useState(0)
+  // * 옵션 버튼 하나의 너비
+  const [registBtnWidth, setRegistBtnWidth] = useState<number>()
+
+  const windowWidth = useWindowDimensions().width
+  // * 버튼이 갑자기 늘어나면서 화면이 깜빡이는 현상을 막기 위해, 동기적으로 처리하는 useLayoutEffect 사용
+  useLayoutEffect(() => {
+    setRegistBtnWidth(
+      (windowWidth - BASIC_BACKGROUND_PADDING_WIDTH * 2 - WIDTH_INTERVAL) / NUM_OF_COLS,
+    )
+  }, [windowWidth])
 
   return (
     <ScreenRootView>
@@ -68,8 +77,10 @@ export const ServiceRegistrationScreen: FC<
           marginTop: 20,
         }}
         data={services}
-        // onLayout: 레이아웃이 생성될 때, 해당 레이아웃의 width를 가져올 수 있다
-        onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
+        // ? onLayout: 레이아웃이 생성될 때, 해당 레이아웃의 width를 가져올 수 있다
+        // ! onLayout으로 너비를 설정하게 되면, 렌더링이 끝난 후에야 버튼의 너비를 결정할 수 있으므로 화면 깜빡임 불가피
+        // * -> UX 개선을 위해 onLayout 대신 useWindowDimensions와 useLayoutEffect를 사용
+        // onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
         renderItem={({ item }) => (
           <RegistrationButton
             isActive={selectedOptions.findIndex((value) => value === item.value) !== -1}
@@ -77,7 +88,7 @@ export const ServiceRegistrationScreen: FC<
             onPress={() => handleOptionPress(item.value)}
             onXPress={() => handleXPress(item.value)}
             style={{
-              width: (containerWidth - WIDTH_INTERVAL) / NUM_OF_COLS,
+              width: registBtnWidth,
             }}
           />
         )}


### PR DESCRIPTION
- 화면이 처음 렌더링될 때, 서비스 버튼들의 가로 너비가 갑자기 늘어나는 문제 해결
👉🏻 onLayout을 사용하지 않고, `useWindowDimensions`와 `useLayoutEffect` 사용 _(onLayout을 사용하면 렌더링 이후에 너비 값을 결정할 수 밖에 없기 때문에 문제 발생 불가피)_

- X버튼의 선택 범위를 늘리기 위해 `세로 padding 값`을 늘리면, _버튼 클릭할 때마다 버튼의 높이가 바뀌는 문제_ 해결 
👉🏻 버튼이 `비활성화 상태`일 때는 버튼에 paddingVertical 값을 넣어주고, 버튼이 `활성화 상태`일 때는 버튼에 paddingVertical 값을 없애는 대신, X 버튼에 paddingVertical 값을 넣어줌

⚠️ 버튼에 있는 `텍스트 높이`와 `X버튼의 높이`가 서로 다르기 때문에, 비활성화된 버튼의 paddingVertical 값은 `8`이고 X 버튼 paddingVertical 값은 `14`로 서로 다름 -> 따라서 이 방안이 정확한 해결 방안인지 확실하지 X

❓ X 버튼 이미지가 처음 등장할 때 약간의 로딩이 발생하는데(아마 lazy loading ?) 이미지를 미리 로딩해두어 맨 처음 X 버튼이 활성화될 때 로딩을 줄일 수 있는 방법 ??