### PR TITLE
Mvp 30/pr#129 코드리뷰 피드백 반영

### DIFF
--- a/app/screens/set-visiting-service-day/set-visiting-service-day-screen.tsx
+++ b/app/screens/set-visiting-service-day/set-visiting-service-day-screen.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react"
+import React, { FC, useCallback, useRef, useState } from "react"
 import {
   StyleSheet,
   View,
@@ -13,7 +13,10 @@ import { observer } from "mobx-react-lite"
 import { StackScreenProps } from "@react-navigation/stack"
 import { NavigatorParamList } from "#navigators"
 import {
+  BASIC_BACKGROUND_PADDING_WIDTH,
+  ConditionalButton,
   DivisionLine,
+  PopSem16,
   PopSem24,
   PreBol14,
   PreBol16,
@@ -25,12 +28,31 @@ import {
   PreReg14,
   PreReg16,
   Screen,
+  TimePicker,
 } from "#components"
 import { BODY, GIVER_CASUAL_NAVY, LBG, LIGHT_LINE } from "#theme"
 import { POPPINS_SEMIBOLD } from "#fonts"
 import { images } from "#images"
+import BottomSheet from "@gorhom/bottom-sheet"
 // import { useNavigation } from "@react-navigation/native"
 // import { useStores } from "#models"
+
+// Calculate the number of minutes passed since the start of the hour
+const now = new Date()
+const minutesPassed = now.getMinutes()
+
+// Calculate how many minutes remain to reach the nearest multiple of 5
+const remainder = minutesPassed % 5
+
+// Subtract the remainder from the current minutes to get the nearest past time in 5-minute intervals
+const nearestPastTime = new Date(now)
+
+// 지금 시간으로 부터 가장 가까운 5분단위 과거 시간
+nearestPastTime.setMinutes(minutesPassed - remainder)
+// console.log(nearestPastTime)
+
+// "지금 시간으로 부터 가장 가까운 5분단위 과거 시간" 에서 딱 1시간 뒤
+const oneHourLaterFromNearestPastTime = new Date(nearestPastTime.getTime() + 60 * 60 * 1000)
 
 // [주의] app/navigators/app-navigator.tsx 에 위치한, NavigatorParamList 변수에 새로운 값 "xxxx-screen": undefined 을 추가해주세요.
 // 그 뒤에는 아래에 있는 @ts-ignore 를 제거해도, 빨간줄이 뜨지 않습니다 :)
@@ -42,6 +64,75 @@ export const SetVisitingServiceDayScreen: FC<
   const toggleSwitch = () => {
     setIsEnabled((prev) => !prev)
   }
+
+  //* 시간선택 - TimePicker
+  const [beginDate, setBeginDate] = useState<Date>(nearestPastTime) // `지금 시간으로 부터 가장 가까운 5분단위 과거 시간`으로 초기값 세팅
+  const [endDate, setEndDate] = useState<Date>(oneHourLaterFromNearestPastTime) // `"지금 시간으로 부터 가장 가까운 5분단위 과거 시간" 에서 딱 1시간 뒤`로 초기값 세팅
+  const [selectedTimeText, selectedSetTimeText] = useState("방문시간을 선택해주세요")
+
+  // 시간 선택 BottomSheet -> search-screen 참고!
+  const bottomSheetRef = useRef<BottomSheet>(null)
+
+  // 시간선택 BottomSheet - callbacks
+  const handleSheetChanges = useCallback((index: number) => {
+    console.log("handleSheetChanges", index)
+  }, [])
+
+  const handleBottomSheet = (isOpen) => {
+    if (isOpen) {
+      bottomSheetRef.current?.expand()
+    } else {
+      bottomSheetRef.current?.collapse()
+    }
+  }
+
+  const timeText = (time: Date) => {
+    const hours = time.getHours()
+    const minute = time.getMinutes()
+    return `${hours.toString().padStart(2, "0")}:${minute.toString().padStart(2, "0")}`
+  }
+
+  const closeBottomSheet = () => {
+    const beginDateText = timeText(beginDate)
+    const endDateText = timeText(endDate)
+    selectedSetTimeText(`${beginDateText} - ${endDateText}`)
+
+    bottomSheetRef.current?.close()
+  }
+
+  console.log(selectedTimeText.length)
+
+  // 서비스 시간 : 오전(오후) 08:00 ~ 오전(오후) 03:00
+  const ServiceTime = (props) => {
+    return (
+      <View style={[styles.box, { marginBottom: 12 }]}>
+        <View style={{ flexDirection: "row", alignItems: "center" }}>
+          <PreReg16 text="오전" mr={4} />
+          <PopSem16 text={props.startTime} />
+          <PreReg16 text="~" mr={10} />
+          <PreReg16 text="오후" mr={4} />
+          <PopSem16 text={props.endTime} />
+        </View>
+        <Image style={styles.image} source={images.x_grey} />
+      </View>
+    )
+  }
+
+  // 강아지크기별 가격
+  const PricePerSize = (props) => {
+    return (
+      <View>
+        <PreReg14 text={props.size} mb={8} color={BODY} style={{ textAlign: "center" }} />
+        <PreMed14 text={`+${props.price}원`} style={{ textAlign: "center" }} />
+      </View>
+    )
+  }
+
+  // 저장하기 버튼 클릭시 데이터 POST
+  const onPress = () => {
+    console.log("데이터 POST")
+  }
+
   // MST store 를 가져옵니다.
   // const { someStore, anotherStore } = useStores()
 
@@ -65,29 +156,11 @@ export const SetVisitingServiceDayScreen: FC<
         </View>
         <View style={styles.line} />
         <PreMed18 text="서비스 시간대" mt={16} ml={16} mb={12} />
-        <View style={[styles.box, { marginBottom: 12 }]}>
-          <View style={{ flexDirection: "row", alignItems: "center" }}>
-            <PreReg16 text="오전" mr={4} />
-            <Text style={styles.text}>08:00</Text>
-            <PreReg16 text="~" mr={10} />
-            <PreReg16 text="오후" mr={4} />
-            <Text style={styles.text}>03:00</Text>
-          </View>
-          <Image style={styles.image} source={images.x_grey} />
-        </View>
-        <View style={styles.box}>
-          <View style={{ flexDirection: "row", alignItems: "center" }}>
-            <PreReg16 text="오후" mr={4} />
-            <Text style={styles.text}>03:30</Text>
-            <PreReg16 text="~" mr={10} />
-            <PreReg16 text="오후" mr={4} />
-            <Text style={styles.text}>05:00</Text>
-          </View>
-          <Image style={styles.image} source={images.x_grey} />
-        </View>
-        <Pressable style={styles.boxTwo}>
+        <ServiceTime startTime="08:00" endTime="04:00" style={{ marginBottom: 12 }} />
+        <ServiceTime startTime="03:00" endTime="05:00" />
+        <Pressable style={styles.boxTwo} onPress={() => handleBottomSheet(true)}>
           <Image style={styles.image} source={images.plus_grey} />
-          <PreReg16 text="가능한 시간 추가하기" ml={12} />
+          <PreReg16 text="가능한 시간 추가하기" ml={12} color={BODY} />
         </Pressable>
         <View style={styles.line} />
         <View style={[styles.rowText, { marginTop: 20 }]}>
@@ -112,20 +185,11 @@ export const SetVisitingServiceDayScreen: FC<
           </View>
         </View>
         <View style={styles.dogSizeBox}>
-          <View>
-            <PreReg14 text="소형견" mb={8} />
-            <PreMed14 text="+0원" />
-          </View>
+          <PricePerSize size="소형견" price="0" />
           <View style={styles.verticalLine} />
-          <View>
-            <PreReg14 text="중형견" mb={8} />
-            <PreMed14 text="+0원" />
-          </View>
+          <PricePerSize size="중형견" price="1000" />
           <View style={styles.verticalLine} />
-          <View>
-            <PreReg14 text="대형견" mb={8} />
-            <PreMed14 text="+0원" />
-          </View>
+          <PricePerSize size="대형견" price="2000" />
         </View>
         <View style={styles.totalPriceBox}>
           <View>
@@ -134,14 +198,56 @@ export const SetVisitingServiceDayScreen: FC<
           </View>
           <View style={{ flexDirection: "row", alignItems: "center" }}>
             {/* <Text style={styles.totalPrice}>9,400</Text> */}
-            <PopSem24>9,400</PopSem24>
+            <PopSem24 text="9400" color={GIVER_CASUAL_NAVY} />
             <PreBol16 text="원" ml={2} />
           </View>
+        </View>
+
+        <BottomSheet
+          ref={bottomSheetRef}
+          index={-1}
+          snapPoints={["80%"]}
+          onChange={handleSheetChanges}
+          backgroundStyle={$bottomSheetBackgroundStyleForShadow}
+          enablePanDownToClose
+        >
+          <TimePicker
+            beginDate={beginDate}
+            setBeginDate={setBeginDate}
+            endDate={endDate}
+            setEndDate={setEndDate}
+          />
+
+          <View style={{ paddingHorizontal: 16, marginBottom: 20 }}>
+            <ConditionalButton label={"확인"} isActivated onPress={closeBottomSheet} />
+          </View>
+        </BottomSheet>
+
+        {/* 저장하기 버튼 클릭시 데이터 POST */}
+        <View
+          style={{
+            paddingHorizontal: BASIC_BACKGROUND_PADDING_WIDTH,
+          }}
+        >
+          <ConditionalButton label="저장하기" isActivated onPress={onPress} />
         </View>
       </ScrollView>
     </Screen>
   )
 })
+
+const $bottomSheetBackgroundStyleForShadow: ViewStyle = {
+  backgroundColor: "white",
+  borderRadius: 32,
+  elevation: 8,
+  shadowColor: "black",
+  shadowOffset: {
+    width: 2,
+    height: 2,
+  },
+  shadowOpacity: 0.2,
+  shadowRadius: 20,
+}
 
 const styles = StyleSheet.create({
   root: {

--- a/app/screens/set-visiting-service-day/set-visiting-service-day-screen.tsx
+++ b/app/screens/set-visiting-service-day/set-visiting-service-day-screen.tsx
@@ -29,6 +29,7 @@ import {
   PreReg16,
   Screen,
   TimePicker,
+  WeightModal,
 } from "#components"
 import { BODY, GIVER_CASUAL_NAVY, LBG, LIGHT_LINE } from "#theme"
 import { POPPINS_SEMIBOLD } from "#fonts"
@@ -69,6 +70,22 @@ export const SetVisitingServiceDayScreen: FC<
   const [beginDate, setBeginDate] = useState<Date>(nearestPastTime) // `지금 시간으로 부터 가장 가까운 5분단위 과거 시간`으로 초기값 세팅
   const [endDate, setEndDate] = useState<Date>(oneHourLaterFromNearestPastTime) // `"지금 시간으로 부터 가장 가까운 5분단위 과거 시간" 에서 딱 1시간 뒤`로 초기값 세팅
   const [selectedTimeText, selectedSetTimeText] = useState("방문시간을 선택해주세요")
+  const [newTime, setNewTime] = useState(false)
+
+  // 시간당 가격 설정 모달 관련 state
+  const [priceModalOpen, setPricemodalOpen] = useState(false)
+  const [price, setPrice] = useState(null)
+
+  // 시간당 가격 설정 모달 관련 함수
+  const handlepriceModalHide = () => {
+    setPricemodalOpen(false)
+  }
+
+  const handlePriceInput = (newPrice) => {
+    setPrice(newPrice)
+    // isChangeMade()
+  }
+  console.log(price)
 
   // 시간 선택 BottomSheet -> search-screen 참고!
   const bottomSheetRef = useRef<BottomSheet>(null)
@@ -97,10 +114,12 @@ export const SetVisitingServiceDayScreen: FC<
     const endDateText = timeText(endDate)
     selectedSetTimeText(`${beginDateText} - ${endDateText}`)
 
+    setNewTime(true)
     bottomSheetRef.current?.close()
   }
 
-  console.log(selectedTimeText.length)
+  console.log(newTime)
+  console.log(selectedTimeText)
 
   // 서비스 시간 : 오전(오후) 08:00 ~ 오전(오후) 03:00
   const ServiceTime = (props) => {
@@ -129,20 +148,17 @@ export const SetVisitingServiceDayScreen: FC<
   }
 
   // 저장하기 버튼 클릭시 데이터 POST
-  const onPress = () => {
-    console.log("데이터 POST")
-  }
+  // const onPress = () => {
+  //   console.log("데이터 POST")
+  // }
 
-  // MST store 를 가져옵니다.
-  // const { someStore, anotherStore } = useStores()
-
-  // 필요시, useNavigation 훅을 사용할 수 있습니다.
-  // const navigation = useNavigation()
   return (
     <Screen testID="SetVisitingServiceDay" style={styles.root}>
       <ScrollView>
         <PreBol20 text="날짜 5개" mb={10} ml={16} />
         <DivisionLine height={8} />
+
+        {/* 서비스 가능 토글 영역 */}
         <View style={styles.servicePossible}>
           <PreMed18 text="서비스 가능" />
           <Switch
@@ -154,15 +170,27 @@ export const SetVisitingServiceDayScreen: FC<
             style={styles.switch}
           />
         </View>
+
         <View style={styles.line} />
+
+        {/* 가능한 서비스 시간대 & 시간 추가하기 */}
         <PreMed18 text="서비스 시간대" mt={16} ml={16} mb={12} />
         <ServiceTime startTime="08:00" endTime="04:00" style={{ marginBottom: 12 }} />
         <ServiceTime startTime="03:00" endTime="05:00" />
+        {newTime && (
+          <ServiceTime
+            startTime={selectedTimeText.slice(0, 5)}
+            endTime={selectedTimeText.slice(8, 13)}
+          />
+        )}
         <Pressable style={styles.boxTwo} onPress={() => handleBottomSheet(true)}>
           <Image style={styles.image} source={images.plus_grey} />
           <PreReg16 text="가능한 시간 추가하기" ml={12} color={BODY} />
         </Pressable>
+
         <View style={styles.line} />
+
+        {/* 서비스 요금 설정 시작 */}
         <View style={[styles.rowText, { marginTop: 20 }]}>
           <PreMed18 text="서비스 요금 설정" />
           <View style={{ flexDirection: "row", alignItems: "center" }}>
@@ -170,13 +198,20 @@ export const SetVisitingServiceDayScreen: FC<
             <Image style={styles.image} source={images.more_info_bigger} />
           </View>
         </View>
+
+        {/* 서비스 요금 설정 - 시간당 요금 설정 */}
         <View style={[styles.rowText, { marginTop: 25 }]}>
           <PreReg16 text="시간 당" />
-          <View style={{ flexDirection: "row", alignItems: "center" }}>
+          <Pressable
+            style={{ flexDirection: "row", alignItems: "center" }}
+            onPress={() => setPricemodalOpen(true)}
+          >
             <PreBol16 text="10,000 원" mr={4} />
             <Image style={styles.image} source={images.arrow_right} />
-          </View>
+          </Pressable>
         </View>
+
+        {/* 서비스 요금 설정 - 강아지별 크기 추가 요금 설정 */}
         <View style={[styles.rowText, { marginTop: 18, marginBottom: 10 }]}>
           <PreReg16 text="강아지 크기 별 추가 요금" />
           <View style={{ flexDirection: "row", alignItems: "center" }}>
@@ -191,17 +226,26 @@ export const SetVisitingServiceDayScreen: FC<
           <View style={styles.verticalLine} />
           <PricePerSize size="대형견" price="2000" />
         </View>
+
+        {/* 시간당 받는 총 금액 */}
         <View style={styles.totalPriceBox}>
           <View>
             <PreBol16 text="내가 시간당 받는 총 금액" mb={4} />
             <PreReg16 text="(수수료 포함)" color={BODY} />
           </View>
           <View style={{ flexDirection: "row", alignItems: "center" }}>
-            {/* <Text style={styles.totalPrice}>9,400</Text> */}
             <PopSem24 text="9400" color={GIVER_CASUAL_NAVY} />
             <PreBol16 text="원" ml={2} />
           </View>
         </View>
+
+        {/* //시간당 가격 설정  모달 */}
+        <WeightModal
+          visibleState={priceModalOpen}
+          handleModalHide={handlepriceModalHide}
+          title="시간당 받을 요금을 입력해주세요(원)"
+          handleInput={handlePriceInput}
+        />
 
         <BottomSheet
           ref={bottomSheetRef}
@@ -224,13 +268,13 @@ export const SetVisitingServiceDayScreen: FC<
         </BottomSheet>
 
         {/* 저장하기 버튼 클릭시 데이터 POST */}
-        <View
+        {/* <View
           style={{
             paddingHorizontal: BASIC_BACKGROUND_PADDING_WIDTH,
           }}
         >
           <ConditionalButton label="저장하기" isActivated onPress={onPress} />
-        </View>
+        </View> */}
       </ScrollView>
     </Screen>
   )
@@ -300,7 +344,6 @@ const styles = StyleSheet.create({
     borderStyle: "solid",
     borderColor: LIGHT_LINE,
     borderRadius: 10,
-    marginTop: 12,
     marginBottom: 28,
     flexDirection: "row",
   },
@@ -335,11 +378,6 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     flexDirection: "row",
     justifyContent: "space-between",
-  },
-  totalPrice: {
-    fontFamily: POPPINS_SEMIBOLD,
-    fontSize: 24,
-    color: GIVER_CASUAL_NAVY,
   },
   image: {
     width: 16,


### PR DESCRIPTION
리뷰요청

반영된 것

1.  가능한 시간 추가하기 클릭 시, 시간 선택 BottomSheet 추가
2.  시간 선택 후 확인 버튼 누르면 BottomSheet closed ->  선택된 시간 스크린에 반영(서비스 시간대 추가) +이미지 첨부
3.  저장하기 버튼 추가, 아직 api 연결은 안된 상태
4.  시간당 가격 설정 모달 추가

수정해야 할 사항

1.  위 2번 구현을 위해 newTime state 추가. 그리고 바텀시트가 닫힐 때, setNewTime(true) 반영.  true 인 경우, 서비스 시간대 추가됨. 그러나 스크린에 시간은 추가되지만 바텀시트를 닫을 때 자연스럽게 닫히지 않음(두번 닫아야하는 문제 발생).  또한 한번만 시간을 설정할 수 있음. 가능한 시간을 여러번 추가하는 경우는 아직 구현하지 못함.  해당 문제(바텀시트 닫을 때 두번 닫아야함)를 해결하고 구현해보겠음.
2.  위 2번에서 오전, 오후는 항상 고정됨. selectedTimeText state에 am, pm도 고려해주면 selectedTimeText state에 따라서 오전 오후 반영할 수 있으나 selectedTimeText는 현재 시간만 나옴.(05:00 ~ 06:00) 따라서 selectedTimeText -> am 11:00 ~ pm:1:00 이렇게 반영되길 원함.
3.  위 3번에서 저장하기 버튼 추가시 시간 선택 BottomSheet가 오픈될 때도 저장하기 버튼이 고정되어 있음. 그래서 시간선택 BottomSheet를 닫을 수 없어서 일단 저장하기 버튼 주석처리하고 작업 진행했음

[image](https://github.com/Care-Giver/CareGiver/assets/114209093/0fed4732-6d7c-4e63-9bc6-67ee1ab731c8)

아직 수정해야할 문제들이 많으나 혼자 해결하지 못할 거 같아서 일단  pull request하고 작업 이어하면서 계속 고민해보겠습니다!