### PR TITLE
Mvp 35/네이버로그인 구축

### DIFF
--- a/app/screens/login/login-screen.tsx
+++ b/app/screens/login/login-screen.tsx
@@ -13,14 +13,12 @@ import {
   KakaoOAuthToken,
   KakaoProfile,
 } from "@react-native-seoul/kakao-login"
-import appleAuth, {
-  AppleRequestOperation,
-  AppleRequestScope,
-} from "@invertase/react-native-apple-authentication"
+import appleAuth from "@invertase/react-native-apple-authentication"
+import NaverLogin, { NaverLoginResponse, GetProfileResponse } from "@react-native-seoul/naver-login"
 import { GIVER_CASUAL_NAVY, KAKAO_YELLOW, NAVER_GREEN, palette } from "#theme"
 import { useStores } from "#models"
 import { alertModal } from "../../utils/alert-modal"
-import { AppleLoginOutput, appleServerLogin } from "#axios"
+import { AppleLoginOutput, appleServerLogin, naverServiceLogin } from "#axios"
 
 export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen">> = observer(
   function LoginScreen() {
@@ -53,6 +51,49 @@ export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen"
      * [테스트 결과]
      * login:
      * - 로그인 진행
+     * - 웹 뷰를 통해 네이버 로그인을 진행하고, accessToken을 받아옴.
+     * - accessToken을 백엔드 서버에 전달하여 로그인된 유저 토큰을 받아옴.
+     */
+    async function signInWithNaver() {
+      try {
+        const consumerKey = "jqWkGdkKVZ3RwlfExH0O"
+        const consumerSecret = "Xi6mBF88oM"
+        const appName = "Care Giver"
+        const serviceUrlScheme = "caregivernaverlogin"
+        const { failureResponse, successResponse } = await NaverLogin.login({
+          appName,
+          consumerKey,
+          consumerSecret,
+          serviceUrlScheme,
+        })
+
+        if (failureResponse) {
+          console.error("naverLogin Error: ", failureResponse.message)
+          alertModal("네이버 로그인 실패", failureResponse.message)
+          return
+        }
+
+        if (successResponse) {
+          console.log(successResponse)
+          // TODO: Send the accessToken to your server for verification and sign-in
+          const userToken = await naverServiceLogin(successResponse.accessToken)
+
+          setLoggedIn(true)
+          setRefreshToken(userToken)
+
+          setResult(userToken)
+        }
+        return successResponse.accessToken
+      } catch (error) {
+        console.error("Naver sign-in error", error)
+        alertModal("네이버 로그인 실패", error?.message)
+      }
+    }
+
+    /**
+     * [테스트 결과]
+     * login:
+     * - 로그인 진행
      * - 현재 기기에 등록되어있는 AppleID를 가지고 와 로그인 진행
      * - 해당 아이디에 비밀번호 입력 후, 로그인 완료 처리됨
      * - 유저 토큰을 setRefreshToken에 일단 등록하나, 명칭 변경이 필요해보임.
@@ -76,8 +117,6 @@ export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen"
 
         // Call your own server API
         const userToken = await appleServerLogin(identityToken)
-
-        console.log(userToken)
 
         // 4. state를 업데이트한다.
         setLoggedIn(true)
@@ -148,7 +187,8 @@ export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen"
 
     const naverLogin = async () => {
       //
-      alertModal("네이버 로그인", "개발중")
+      await signInWithNaver()
+      goBack()
     }
 
     const googleLogin = async () => {
@@ -174,6 +214,7 @@ export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen"
           break
 
         case "naver":
+          naverLogOut()
           break
 
         case "apple":
@@ -206,8 +247,26 @@ export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen"
       }
     }
 
+    /**
+     * [테스트 결과]
+     * - 로그인 캐시를 삭제하여 다른 네이버 아이디로도 로그인 가능하도록 함.
+     * - 해당 함수 호출하지 않을 시 이전에 캐싱된 네이버 아이디로 로그인 됨.
+     */
+    const signOutWithNaver = async (): Promise<void> => {
+      try {
+        await NaverLogin.logout()
+        setLoggedIn(false)
+      } catch (err) {
+        console.error("signOut error", err)
+      }
+    }
+
     const kakaoLogOut = async () => {
       await signOutWithKakao()
+    }
+
+    const naverLogOut = async () => {
+      await signOutWithNaver()
     }
 
     console.log("loggedIn OUTSIDE >>>", loggedIn)

--- a/app/services/axios/login.ts
+++ b/app/services/axios/login.ts
@@ -5,7 +5,15 @@ interface AppleLoginInput {
   idToken: string
 }
 
+interface NaverLoginInput {
+  idToken: string
+}
+
 export interface AppleLoginOutput extends GeneralResponse {
+  token?: string
+}
+
+export interface NaverLoginOutput extends GeneralResponse {
   token?: string
 }
 
@@ -18,6 +26,30 @@ export const appleServerLogin = async (idToken: string): Promise<string> => {
     const response = await axios.post<AppleLoginOutput>(`${BASE_URL}/user/login/apple`, {
       idToken,
     } as AppleLoginInput)
+
+    if (!response.data.ok) {
+      const error = response.data.error
+      console.error("response.data.error 에러!!!", error)
+      // @ts-ignore
+      return error
+    }
+
+    return response.data.token
+  } catch (error) {
+    console.error("catch 에러!!!", error)
+    return ""
+  }
+}
+
+/**
+ * 네이버 로그인 요청을 서버에 보낸다.
+ * @returns {Promise<string>} token
+ */
+export const naverServiceLogin = async (idToken: string): Promise<string> => {
+  try {
+    const response = await axios.post<NaverLoginOutput>(`${BASE_URL}/user/login/naver`, {
+      idToken,
+    } as NaverLoginInput)
 
     if (!response.data.ok) {
       const error = response.data.error

--- a/ios/CareGiver.xcodeproj/project.pbxproj
+++ b/ios/CareGiver.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				74EC035B08A4614EC7FD4F66 /* [CP] Copy Pods Resources */,
 				0E0ADBDF4F589ED378353CF2 /* [CP-User] [RNFB] Core Configuration */,
+				834D0CE8CE5C7640480A2434 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -305,6 +306,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CareGiver/Pods-CareGiver-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		834D0CE8CE5C7640480A2434 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CareGiver/Pods-CareGiver-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/naveridlogin-sdk-ios/NaverThirdPartyLogin.framework/NaverThirdPartyLogin",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NaverThirdPartyLogin.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CareGiver/Pods-CareGiver-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DCA0ACD03A97AABF952E8D45 /* [CP] Check Pods Manifest.lock */ = {

--- a/ios/CareGiver/Info.plist
+++ b/ios/CareGiver/Info.plist
@@ -29,6 +29,8 @@
 			</array>
 		</dict>
 		<dict>
+			<key>CFBundleIdentifier</key>
+			<string></string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
@@ -36,77 +38,84 @@
 				<string>kakaob6bb8137d93b8b5a3f7c565453235ba4</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>caregivernaverlogin</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1.0.0</string>
 	<key>KAKAO_APP_KEY</key>
- <string>b6bb8137d93b8b5a3f7c565453235ba4</string>
-  <key>LSApplicationQueriesSchemes</key>
-  <array>
-    <string>kakaokompassauth</string> 
-    <string>storykompassauth</string>
-    <string>kakaolink</string>
-	<string>kftc-bankpay</string> <!-- 계좌이체 -->
-	<string>ispmobile</string> <!-- ISP모바일 -->
-	<string>itms-apps</string> <!-- 앱스토어 -->
-	<string>hdcardappcardansimclick</string> <!-- 현대카드-앱카드 -->
-	<string>smhyundaiansimclick</string> <!-- 현대카드-공인인증서 -->
-	<string>shinhan-sr-ansimclick</string> <!-- 신한카드-앱카드 -->
-	<string>smshinhanansimclick</string> <!-- 신한카드-공인인증서 -->
-	<string>kb-acp</string> <!-- 국민카드-앱카드 -->
-	<string>mpocket.online.ansimclick</string> <!-- 삼성카드-앱카드 -->
-	<string>ansimclickscard</string> <!-- 삼성카드-온라인결제 -->
-	<string>ansimclickipcollect</string> <!-- 삼성카드-온라인결제 -->
-	<string>vguardstart</string> <!-- 삼성카드-백신 -->
-	<string>samsungpay</string> <!-- 삼성카드-삼성페이 -->
-	<string>scardcertiapp</string> <!-- 삼성카드-공인인증서 -->
-	<string>lottesmartpay</string> <!-- 롯데카드-모바일결제 -->
-	<string>lotteappcard</string> <!-- 롯데카드-앱카드 -->
-	<string>cloudpay</string> <!-- 하나카드-앱카드 -->
-	<string>nhappcardansimclick</string> <!-- 농협카드-앱카드 -->
-	<string>nonghyupcardansimclick</string> <!-- 농협카드-공인인증서 -->
-	<string>citispay</string> <!-- 씨티카드-앱카드 -->
-	<string>citicardappkr</string> <!-- 씨티카드-공인인증서 -->
-	<string>citimobileapp</string> <!-- 씨티카드-간편결제 -->
-	<string>kakaotalk</string> <!-- 카카오톡 -->
-	<string>payco</string> <!-- 페이코 -->
-	<string>lpayapp</string> <!-- (구)롯데 L페이 -->
-	<string>hanamopmoasign</string> <!-- 하나카드 공인인증앱 -->
-	<string>wooripay</string> <!-- (구) 우리페이 -->
-	<string>nhallonepayansimclick</string> <!-- NH 올원페이 -->
-	<string>hanawalletmembers</string> <!-- 하나카드(하나멤버스 월렛) -->
-	<string>chaipayment</string> <!-- 차이 -->
-	<string>kb-auth</string> <!-- 국민 -->
-	<string>hyundaicardappcardid</string>  <!-- 현대카드 -->
-	<string>com.wooricard.wcard</string>  <!-- 우리won페이 -->
-	<string>lmslpay</string>  <!-- 롯데 L페이 -->
-	<string>lguthepay-xpay</string>  <!-- 페이나우 -->
-	<string>liivbank</string>  <!-- Liiv 국민 -->
-	<string>supertoss</string> <!-- 토스 -->
-	<string>newsmartpib</string> <!-- 우리WON뱅킹 -->
-	<string>ukbanksmartbanknonloginpay</string> <!-- 케이뱅크 페이 -->
-  </array>
+	<string>b6bb8137d93b8b5a3f7c565453235ba4</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>storykompassauth</string>
+		<string>kakaolink</string>
+		<string>kftc-bankpay</string>
+		<string>ispmobile</string>
+		<string>itms-apps</string>
+		<string>hdcardappcardansimclick</string>
+		<string>smhyundaiansimclick</string>
+		<string>shinhan-sr-ansimclick</string>
+		<string>smshinhanansimclick</string>
+		<string>kb-acp</string>
+		<string>mpocket.online.ansimclick</string>
+		<string>ansimclickscard</string>
+		<string>ansimclickipcollect</string>
+		<string>vguardstart</string>
+		<string>samsungpay</string>
+		<string>scardcertiapp</string>
+		<string>lottesmartpay</string>
+		<string>lotteappcard</string>
+		<string>cloudpay</string>
+		<string>nhappcardansimclick</string>
+		<string>nonghyupcardansimclick</string>
+		<string>citispay</string>
+		<string>citicardappkr</string>
+		<string>citimobileapp</string>
+		<string>kakaotalk</string>
+		<string>payco</string>
+		<string>lpayapp</string>
+		<string>hanamopmoasign</string>
+		<string>wooripay</string>
+		<string>nhallonepayansimclick</string>
+		<string>hanawalletmembers</string>
+		<string>chaipayment</string>
+		<string>kb-auth</string>
+		<string>hyundaicardappcardid</string>
+		<string>com.wooricard.wcard</string>
+		<string>lmslpay</string>
+		<string>lguthepay-xpay</string>
+		<string>liivbank</string>
+		<string>supertoss</string>
+		<string>newsmartpib</string>
+		<string>ukbanksmartbanknonloginpay</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
-		<true/>
 		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
 		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-
 			<key>ec2-3-36-101-9.ap-northeast-2.compute.amazonaws.com</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
 		</dict>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -208,6 +208,7 @@ PODS:
     - nanopb/encode (= 2.30909.0)
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
+  - naveridlogin-sdk-ios (4.1.6)
   - PromisesObjC (2.2.0)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -519,6 +520,9 @@ PODS:
     - React-Core
   - RNKeychain (6.2.0):
     - React
+  - RNNaverLogin (3.0.0-rc.2):
+    - naveridlogin-sdk-ios (~> 4.1.5)
+    - React
   - RNReanimated (2.9.1):
     - DoubleConversion
     - FBLazyVector
@@ -626,6 +630,7 @@ DEPENDENCIES:
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
+  - "RNNaverLogin (from `../node_modules/@react-native-seoul/naver-login`)"
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -650,6 +655,7 @@ SPEC REPOS:
     - KakaoSDKUser
     - lottie-ios
     - nanopb
+    - naveridlogin-sdk-ios
     - PromisesObjC
 
 EXTERNAL SOURCES:
@@ -792,6 +798,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-gesture-handler"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
+  RNNaverLogin:
+    :path: "../node_modules/@react-native-seoul/naver-login"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -852,6 +860,7 @@ SPEC CHECKSUMS:
   lottie-ios: 8f97d3271e155c2d688875c29cd3c74908aef5f8
   lottie-react-native: 8f9d4be452e23f6e5ca0fdc11669dc99ab52be81
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  naveridlogin-sdk-ios: cdd34e3585a3d5aaf37c1d84c1f41faba4a25d1a
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: c8c080849a3670601d5c7056023a2176067a69d8
@@ -893,6 +902,7 @@ SPEC CHECKSUMS:
   RNFBApp: a6fca2cd8f392b5efc1f2ab7bd4b3b64a6039abf
   RNGestureHandler: bad495418bcbd3ab47017a38d93d290ebd406f50
   RNKeychain: b8e0711b959a19c5b057d1e970d3c83d159b6da5
+  RNNaverLogin: 01ca478665ea024e4ddaa02be38396845fcac0b6
   RNReanimated: 2cf7451318bb9cc430abeec8d67693f9cf4e039c
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   Yoga: 75bf4b0131cfb46a659cd0c13309b79a6fcff66d

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@react-native-firebase/app": "~15.4.0",
     "@react-native-picker/picker": "2.4.2",
     "@react-native-seoul/kakao-login": "^5.2.6",
+    "@react-native-seoul/naver-login": "^3.0.0-rc.2",
     "@react-navigation/bottom-tabs": "^6.3.2",
     "@react-navigation/native": "~6.0.1",
     "@react-navigation/native-stack": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2985,6 +2985,13 @@
   dependencies:
     dooboolab-welcome "^1.3.2"
 
+"@react-native-seoul/naver-login@^3.0.0-rc.2":
+  version "3.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native-seoul/naver-login/-/naver-login-3.0.0-rc.2.tgz#fadfedff123eb58bbc3c3f0fd286aa3a4970b117"
+  integrity sha512-/gI0WJC6FLgSOLYrDAPehs9x34vFfBgdA5wER8hiwFB4g+DjXdGd+0NuT4+ISzTYfhHTG4cBHqa70oGBs5uxtQ==
+  dependencies:
+    dooboolab-welcome "^1.3.2"
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"


### PR DESCRIPTION
## 작업 요약
이번 PR에서는 네이버 로그인 기능을 성공적으로 API 서버와 연동하였습니다. 이를 통해 사용자가 안드로이드 및 iOS 환경에서 모두 네이버 로그인을 사용하여 로그인 할 수 있습니다.

## 질문 사항 및 논의 필요 사항
1. 안드로이드 및 iOS에서 네이버 로그인이 전부 가능합니다. 그러나 안드로이드에서 애플로그인을 터치하면 에러가 발생하는 모습을 볼 수 있었습니다. 안드로이드에서 아예 애플로그인 버튼을 없애는 것이 가능하다면 가장 간편할 것 같습니다.

2. 네이버로그인의 경우 다음과 같이 다양한 메타데이터를 가져올 수 있습니다. 이를 통해 애플로그인과는 달리 회원가입이 바로 가능한데요, 이 부분에 있어 
    a. 회원가입 시 스크린으로 연결하되 미리 메타데이터를 입력한 채로 이동하기 
    b. 그냥 무시하고 새로 입력받기 
    c. 애플로그인과는 달리 바로 회원가입 처리되도록 하기
세가지 방법 중 어느 것을 사용할 지 수민님과 논의가 필요할 것 같습니다.
```  
response: {
    email: string;
    nickname: string;
    profile_image: string;
    age: string;
    gender: string;
    id: string;
    name: string;
    birthday: string;
  };
 ```

3. 보안을 위해 현재 코드에는 그대로 사용되고 있는
```  
const consumerKey = "jqWkGdkKVZ3RwlfExH0O"
const consumerSecret = "Xi6mBF88oM"
const appName = "Care Giver"
const serviceUrlScheme = "caregivernaverlogin"
```  
이 변수들을 환경변수 처리하는 것이 필요합니다. 앞선 회의에서 말씀드린 보안 관련된 내용 전달드릴 때 다시 말씀드리도록 하겠습니다.
