### PR TITLE
Mvp 36/카카오로그인 구축

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,15 +34,16 @@
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
+    </activity>
+    <activity android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity" android:exported="true">
       <intent-filter>
-        <action android:name="android.intent.action.VIEW"/>
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="pet.caregiver"/>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
 
-        <!-- Redirect URI: "kakao{NATIVE_APP_KEY}://oauth“ -->
-        <data android:host="oauth"
-            android:scheme="kakaob6bb8137d93b8b5a3f7c565453235ba4" />
+          <!-- Redirect URI: "kakao{NATIVE_APP_KEY}://oauth“ -->
+          <data android:host="oauth"
+                android:scheme="kakaob6bb8137d93b8b5a3f7c565453235ba4" />
       </intent-filter>
     </activity>
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,6 +66,8 @@ allprojects {
             }
         }
         maven { url 'https://www.jitpack.io' }
+        // for kakao login
+        maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/'}
     }
 }
 

--- a/app/screens/login/login-screen.tsx
+++ b/app/screens/login/login-screen.tsx
@@ -20,7 +20,7 @@ import appleAuth, {
 import { GIVER_CASUAL_NAVY, KAKAO_YELLOW, NAVER_GREEN, palette } from "#theme"
 import { useStores } from "#models"
 import { alertModal } from "../../utils/alert-modal"
-import { AppleLoginOutput, appleServerLogin } from "#axios"
+import { AppleLoginOutput, appleServerLogin, kakaoServerLogin } from "#axios"
 
 export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen">> = observer(
   function LoginScreen() {
@@ -37,12 +37,18 @@ export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen"
      * - 딥링크를 통해, 카카오톡을 실행하며, 카카오톡에 로그인되어있다면
      * - 개인정보 이용동의 후, 로그인 완료 처리됨
      * - 만약, 카카오톡 접근이 불가하다면, loginWithKakaoAccount 를 호출하여 웹브라우저를 실행함
+     * - 이후 accessToken을 케어기버 서버로 보내 로그인 진행
      */
     const signInWithKakao = async (): Promise<void> => {
       try {
-        const token: KakaoOAuthToken = await login()
-        setRefreshToken(token.refreshToken)
-        // setResult(JSON.stringify(token))
+        const kakaoLoginResponse: KakaoOAuthToken = await login()
+
+        const userToken = await kakaoServerLogin(kakaoLoginResponse.accessToken)
+
+        setLoggedIn(true)
+        setRefreshToken(userToken)
+
+        setResult(userToken)
       } catch (err) {
         console.error("login err", err)
         alertModal("카카오 로그인 실패", err?.message)
@@ -143,7 +149,7 @@ export const LoginScreen: FC<StackScreenProps<NavigatorParamList, "login-screen"
 
     const kakaoLogin = async () => {
       await signInWithKakao()
-      await getKProfile()
+      goBack()
     }
 
     const naverLogin = async () => {

--- a/app/services/axios/login.ts
+++ b/app/services/axios/login.ts
@@ -9,6 +9,14 @@ export interface AppleLoginOutput extends GeneralResponse {
   token?: string
 }
 
+interface KakaoLoginInput {
+  idToken: string
+}
+
+export interface KakaoLoginOutput extends GeneralResponse {
+  token?: string
+}
+
 /**
  * 애플 로그인 요청을 서버에 보낸다.
  * @returns {Promise<string>} token
@@ -18,6 +26,30 @@ export const appleServerLogin = async (idToken: string): Promise<string> => {
     const response = await axios.post<AppleLoginOutput>(`${BASE_URL}/user/login/apple`, {
       idToken,
     } as AppleLoginInput)
+
+    if (!response.data.ok) {
+      const error = response.data.error
+      console.error("response.data.error 에러!!!", error)
+      // @ts-ignore
+      return error
+    }
+
+    return response.data.token
+  } catch (error) {
+    console.error("catch 에러!!!", error)
+    return ""
+  }
+}
+
+/**
+ * 카카오 로그인 요청을 서버에 보낸다.
+ * @returns {Promise<string>} token
+ */
+export const kakaoServerLogin = async (idToken: string): Promise<string> => {
+  try {
+    const response = await axios.post<KakaoLoginOutput>(`${BASE_URL}/user/login/kakao`, {
+      idToken,
+    } as KakaoLoginInput)
 
     if (!response.data.ok) {
       const error = response.data.error


### PR DESCRIPTION
## 작업 요약
이번 PR에서는 카카오 로그인 기능을 성공적으로 API 서버와 연동하였습니다. 이를 통해 사용자가 카카오 로그인을 수행할 수 있게 되었습니다. 찾기 힘든 에러여서 해결하는데 시간이 오래 걸렸습니다.

안드로이드 한정으로, 카카오로그인에서 카카오톡 어플리케이션이 설치되어있지 않은 경우 로그인 콜백이 없는 에러가 발생하였습니다. 결론적으로 해결을 완료하였으나, 몇몇 안드로이드 설정파일을 수정할 수 밖에 없었습니다.

## 질문 사항 및 논의 필요 사항
1. 안드로이드에서 프로젝트 레벨에서의 `build.gradle` 파일 및 `./android/app/src/main/AndroidManifest.xml`의 수정이 불가피하였습니다. 참고한 문서는 다음과 같습니다.

[카카오 공식문서](https://developers.kakao.com/docs/latest/ko/getting-started/sdk-android)
[react-native-kakao-login 깃허브](https://github.com/crossplatformkorea/react-native-kakao-login#android)
[카카오 로그인 이슈](https://github.com/crossplatformkorea/react-native-kakao-login/issues/340)

2. 회원가입 및 MST연결 업무가 저에게 주어진 것을 확인하였는데, 제가 어떤 업무를 수행하면 되는걸까요?
