### PR TITLE
"위탁" 서비스 관련 UI 숨김

### DIFF
--- a/app/components/_BUTTON/caregiver-type-button/caregiver-type-button.tsx
+++ b/app/components/_BUTTON/caregiver-type-button/caregiver-type-button.tsx
@@ -4,7 +4,7 @@ import { PreBol12 } from "../../_BASIC/custom-texts/custom-texts"
 import { GIVER_CASUAL_NAVY, palette } from "#theme"
 
 interface CaregiverTypeButtonPros {
-  text: "방문" | "위탁" | "펫시터"
+  text: "방문" | "위탁" | "펫시터" | "작성중.."
   textColor?: string
   style?: StyleProp<ViewStyle>
 }

--- a/app/components/service-type-indicator-header/service-type-indicator-header.tsx
+++ b/app/components/service-type-indicator-header/service-type-indicator-header.tsx
@@ -15,11 +15,11 @@ interface ServiceTypeIndicatorHeaderProps {
   label: ServiceType
   state: string
   onPress: () => void
+  isActivated: boolean
 }
 
 export const ServiceTypeIndicatorHeader = (props: ServiceTypeIndicatorHeaderProps) => {
-  const { label, state, onPress, style } = props
-  const isActivated = label === state
+  const { label, state, onPress, isActivated, style } = props
 
   const _styles = Object.assign({}, styles.root, style)
 

--- a/app/components/service-type-indicator-header/styles.ts
+++ b/app/components/service-type-indicator-header/styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from "react-native"
 
 export const styles = StyleSheet.create({
   root: {
-    width: 174,
+    width: "100%",
     height: 35,
     // backgroundColor: "orange",
   },

--- a/app/screens/_CARE_GIVER/cg-edit-profile/cg-edit-profile-screen.tsx
+++ b/app/screens/_CARE_GIVER/cg-edit-profile/cg-edit-profile-screen.tsx
@@ -43,7 +43,7 @@ export const CgEditProfileScreen: FC<
     navigation.setOptions({
       //@ts-ignore
       title: hasDraftPetsitterProfile
-        ? `${draftServiceTypeKorean} 펫시터 [등록중]`
+        ? `${draftServiceTypeKorean} 펫시터 [작성중]`
         : `${serviceTypeKorean} 펫시터`,
     })
   }, [navigation, serviceTypeKorean, draftServiceTypeKorean, hasDraftPetsitterProfile])

--- a/app/screens/_CARE_GIVER/cg-mypage/cg-mypage-screen.tsx
+++ b/app/screens/_CARE_GIVER/cg-mypage/cg-mypage-screen.tsx
@@ -55,7 +55,7 @@ export const CgMypageScreen: FC<
 
   // 처음 펫시터를 등록하는 경우 보여지는 BottomSheetModal BEGIN =======================================================
   // 서비스 타입
-  const [serviceType, setServiceType] = useState<ServiceTypeKorean>(null)
+  const [serviceType, setServiceType] = useState<ServiceTypeKorean>("방문")
 
   // 펫시터 등록하기 바텀시트모달 - ref
   const bottomSheetModalRef = useRef<BottomSheetModal>(null)
@@ -64,37 +64,37 @@ export const CgMypageScreen: FC<
   const snapPoints = useMemo(() => ["40%"], [])
 
   /** 펫시터 등록하기 바텀시트모달 backdrop */
-  const renderBackdrop = useCallback(
-    (props) => (
-      <BottomSheetBackdrop
-        {...props}
-        appearsOnIndex={0} // backdrop이 등장할 때의 snap point -> snap point가 0이면 backdrop 나타남
-        disappearsOnIndex={-1} // backdrop이 사라질 때의 snap point -> snap point가 -1이면 backdrop 사라짐
-        pressBehavior={"close"}
-      />
-    ),
-    [],
-  )
+  // const renderBackdrop = useCallback(
+  //   (props) => (
+  //     <BottomSheetBackdrop
+  //       {...props}
+  //       appearsOnIndex={0} // backdrop이 등장할 때의 snap point -> snap point가 0이면 backdrop 나타남
+  //       disappearsOnIndex={-1} // backdrop이 사라질 때의 snap point -> snap point가 -1이면 backdrop 사라짐
+  //       pressBehavior={"close"}
+  //     />
+  //   ),
+  //   [],
+  // )
 
   /** 펫시터 등록하기 바텀시트모달 Footer - 확인 버튼 렌더링 */
-  const renderFooter = useCallback(
-    (props) => (
-      <BottomSheetFooter {...props} bottomInset={BOTTOM_HEIGHT} style={styles.btnContainer}>
-        <ConditionalButton
-          label={
-            !serviceType ? "방문과 위탁 중에서 선택해주세요." : `${serviceType} 펫시터 시작하기`
-          }
-          isActivated={!!serviceType}
-          onPress={() => {
-            bottomSheetModalRef.current?.close()
-            setDraftPetsitter({}, serviceType === "방문" ? "visiting" : "creche")
-            navigate("cg-registration-1-screen")
-          }}
-        />
-      </BottomSheetFooter>
-    ),
-    [bottomSheetModalRef, serviceType, setDraftPetsitter],
-  )
+  // const renderFooter = useCallback(
+  //   (props) => (
+  //     <BottomSheetFooter {...props} bottomInset={BOTTOM_HEIGHT} style={styles.btnContainer}>
+  //       <ConditionalButton
+  //         label={
+  //           !serviceType ? "방문과 위탁 중에서 선택해주세요." : `${serviceType} 펫시터 시작하기`
+  //         }
+  //         isActivated={!!serviceType}
+  //         onPress={() => {
+  //           bottomSheetModalRef.current?.close()
+  //           setDraftPetsitter({}, serviceType === "방문" ? "visiting" : "creche")
+  //           navigate("cg-registration-1-screen")
+  //         }}
+  //       />
+  //     </BottomSheetFooter>
+  //   ),
+  //   [bottomSheetModalRef, serviceType, setDraftPetsitter],
+  // )
   // 처음 펫시터를 등록하는 경우 보여지는 BottomSheetModal ENDED =======================================================
 
   return (
@@ -132,7 +132,7 @@ export const CgMypageScreen: FC<
               </Row>
 
               <Row>
-                <CaregiverTypeButton text={serviceTypeKorean} />
+                <CaregiverTypeButton text={serviceTypeKorean || "작성중.."} />
                 <CaregiverTypeButton
                   text={"펫시터"}
                   textColor={GIVER_CASUAL_NAVY}
@@ -162,7 +162,9 @@ export const CgMypageScreen: FC<
             <TouchableOpacity
               style={{ marginTop: 16, marginBottom: 28, alignItems: "center" }}
               onPress={() => {
-                bottomSheetModalRef.current?.present()
+                // bottomSheetModalRef.current?.present()
+                setDraftPetsitter({}, serviceType === "방문" ? "visiting" : "creche")
+                navigate("cg-registration-1-screen")
               }}
             >
               <Image
@@ -236,7 +238,7 @@ export const CgMypageScreen: FC<
       </ScrollView>
 
       {/* 펫시터 등록하기 바텀시트모달 - !항상 컴포넌트 최하단에 있을것! */}
-      <BottomSheetModal
+      {/* <BottomSheetModal
         ref={bottomSheetModalRef}
         backdropComponent={renderBackdrop}
         index={0}
@@ -246,7 +248,7 @@ export const CgMypageScreen: FC<
         style={{ paddingHorizontal: BASIC_BACKGROUND_PADDING_WIDTH }}
       >
         <CgSetServiceType serviceType={serviceType} setServiceType={setServiceType} />
-      </BottomSheetModal>
+      </BottomSheetModal> */}
     </Screen>
   )
 })

--- a/app/screens/_CARE_GIVER/cg-registration-2/cg-set-additional-price.tsx
+++ b/app/screens/_CARE_GIVER/cg-registration-2/cg-set-additional-price.tsx
@@ -132,7 +132,11 @@ export const CgSetAdditionalPrice = observer(function CgSetAdditionalPrice(
                       keyboardType="numeric"
                       returnKeyType="done"
                       placeholder={`${강아지_크기}견 추가 요금을 입력해주세요.`}
-                      value={priceFormatter(additionalPrice[value].toString())}
+                      value={
+                        additionalPrice[value]
+                          ? priceFormatter(additionalPrice[value].toString())
+                          : null
+                      }
                       onChangeText={(text) => {
                         setAdditionalPrice({
                           ...additionalPrice,

--- a/app/screens/_CLIENT/favorites/favorites-screen.tsx
+++ b/app/screens/_CLIENT/favorites/favorites-screen.tsx
@@ -99,7 +99,7 @@ export const FavoritesScreen: FC<
   const [serviceType, setServiceType] = useState<"펫시터" | "훈련사">("펫시터")
 
   // * filter states
-  const [filterServiceType, setFilterServiceType] = useState<Service | null>(null)
+  const [filterServiceType, setFilterServiceType] = useState<Service | null>("visiting")
   const [startDate, setStartDate] = useState<DateData | null>(null)
   const [endDate, setEndDate] = useState<DateData | null>(null)
   const [filterPet, setFilterPet] = useState<Pet[]>([])
@@ -473,8 +473,7 @@ export const FavoritesScreen: FC<
             <View style={styles.divisionLine} />
 
             {/* //* 위탁 | 방문 버튼 */}
-            <Row style={{ marginTop: 12, justifyContent: "space-between" }}>
-              {/* // ? 방문 버튼 */}
+            {/* <Row style={{ marginTop: 12, justifyContent: "space-between" }}>
               <Pressable
                 style={[
                   styles.radioContainer,
@@ -499,7 +498,6 @@ export const FavoritesScreen: FC<
                 </View>
               </Pressable>
 
-              {/* // ? 위탁 버튼 */}
               <Pressable
                 style={[
                   styles.radioContainer,
@@ -523,7 +521,7 @@ export const FavoritesScreen: FC<
                   />
                 </View>
               </Pressable>
-            </Row>
+            </Row> */}
 
             {/* //* 날짜 선택 */}
             {isCalendarOpen ? (

--- a/app/screens/_CLIENT/search-stack/search-result-screen/search-result-screen.tsx
+++ b/app/screens/_CLIENT/search-stack/search-result-screen/search-result-screen.tsx
@@ -167,7 +167,7 @@ export const SearchResultScreen: FC<
   useLayoutEffect(() => {
     navigation.setOptions({
       //@ts-ignore
-      title: `펫시팅 - ${serviceType}`,
+      title: `${serviceType} 펫시팅`,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/app/screens/_CLIENT/search-stack/search-screen/search-screen.tsx
+++ b/app/screens/_CLIENT/search-stack/search-screen/search-screen.tsx
@@ -240,30 +240,32 @@ export const SearchScreen: FC<StackScreenProps<NavigatorParamList, "search-scree
             {/* 펫시팅 헤더 이미지 - "나에게 딱맞는 펫시터 찾아보기" */}
             <Image source={images.search_screen_header_image} style={styles.headerImage} />
             {/* //* 방문 | 위탁 */}
-            <Row style={{ marginTop: 44, justifyContent: "space-between" }}>
+            <Row style={{ marginTop: 44, justifyContent: "space-between", width: "100%" }}>
               <ServiceTypeIndicatorHeader
                 onPress={() => {
                   setServiceType("방문")
                 }}
-                label={"방문"}
+                label={"방문 펫시팅 서비스"}
                 state={serviceType}
+                isActivated={serviceType === "방문"}
               />
-              <ServiceTypeIndicatorHeader
+              {/* <ServiceTypeIndicatorHeader
                 onPress={() => {
                   setServiceType("위탁")
                 }}
                 style={{ marginLeft: 10 }}
                 label={"위탁"}
                 state={serviceType}
-              />
+                isActivated={serviceType === "위탁"}
+              /> */}
             </Row>
             <Row style={{ marginTop: 16 }}>
               <Image source={images.right_arrow_grey} style={styles.image} />
               <PreReg14
                 text={
                   serviceType === "방문"
-                    ? "케어기버가 직접 당신의 집을 방문합니다. \n날짜와 시간을 선택해주세요."
-                    : "케어기버가 있는 곳으로 아이를 맡기러 갑니다. \n날짜 범위를 선택해주세요."
+                    ? "펫시터가 직접 당신의 집을 방문합니다. \n날짜와 시간을 선택해주세요."
+                    : "펫시터가 있는 곳으로 아이를 맡기러 갑니다. \n날짜 범위를 선택해주세요."
                 }
                 color={DISABLED}
                 style={styles.text}


### PR DESCRIPTION
# 설명
- [01-27 회의](https://caregiver-frontend.atlassian.net/wiki/x/GICVAg) 결과에 의거, MVP 서비스 범위에서 "위탁" 서비스를 삭제하고, 방문 서비스만 출시하기로 결정하였습니다.
- 따라서, 앱 내에 모든 "위탁" 서비스 관련 UI 를 제거하였습니다.

# 변경 사항
펫시터
- 펫시터 등록과정: cg-mypage-screen
  - 이제 더이상, 방문 OR 위탁 선택 바텀시트모달이 표출되지 않습니다.
  - 모든 유저는 기본적으로 "방문" 펫시터로 프로필이 생성됩니다.

보호자
- 검색 과정: search-screen
  - 이제 더이상, 펫시터 검색시 방문/위탁 옵션이 표출되지 않습니다.
  - 오로지 방문 펫시터만 검색가능합니다. 
- 즐겨찾기: favorites-screen
  - 필터 바텀시트모달에서 방문/위탁 옵션이 표출되지 않습니다.
  - TODO: 즐겨찾기 기능은 재정립 해야 합니다.

# 기타
- 펫시터 등록과정에서, 크기별 추가요금을 선택하는 인풋창의 기본 value 를 null 로 변경하였습니다.