### PR TITLE
Fix: Cache-Control: "no-cache" 헤더 axios 에 추가

### DIFF
--- a/app/navigators/app-navigator.tsx
+++ b/app/navigators/app-navigator.tsx
@@ -176,6 +176,7 @@ const AllTabs = observer(function AllTabs() {
     //! 중요: axios 기본 설정에 토큰을 넣어줘야 한다.
     axios.defaults.headers.common["x-jwt"] = userAuth.token
     axios.defaults.headers.common.Accept = "Application/json"
+    axios.defaults.headers.common["Cache-Control"] = "no-cache"
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 


### PR DESCRIPTION
# What is this PR? | PR 설명 🔍
- 케어기버 API 사용시, 빈번히 304 status 를 반환받을 때가 있습니다.
- 304 반환 시, response 는 비어있게 됨. 즉, 정상적인 로직에서 벗어 납니다.
- 이 문제를 해결하기 위해 Cache-Control 헤더를 "no-cache" 로 변경 하였습니다.
  
# Changes | 핵심 변경사항 📝
- 로그인 시, axios 기본 헤더 설정에서 Cache-Control 헤더를 "no-cache" 로 지정 합니다.

# Screenshots | 스크린샷 📷
- 없음

# Help me | 도와주세요 🤦🏻‍♂️
- 없음
