### PR TITLE
Fix(client-calendar): maxDate 설정 - 60일 초과하는 날짜는 선택 불가능

### DIFF
--- a/app/components/client-calendar/client-calendar.tsx
+++ b/app/components/client-calendar/client-calendar.tsx
@@ -7,6 +7,8 @@ import "./localeConfig"
 import { ClientCalendarDay } from "./client-calendar-day/client-calendar-day"
 import { GIVER_CASUAL_NAVY, GIVER_CASUAL_NAVY_40, SHADOW_1 } from "#theme"
 import { POPPINS_SEMIBOLD } from "#fonts"
+import { addDays, isAfter, parseISO, subDays } from "date-fns"
+import { alertModal } from "../../utils/alert-modal"
 
 interface ClientCalendarProps {
   style: ViewStyle
@@ -18,9 +20,11 @@ interface ClientCalendarProps {
 export const ClientCalendar = observer(function CgCalendar(props: ClientCalendarProps) {
   const { style, selectedDate, onDayPress: onDayPressProp, dateRange } = props
   const $allStyles = Object.assign({}, styles.root, style)
+  const maxDate = addDays(Date.now(), 58)
   return (
     <View style={$allStyles}>
       <Calendar
+        maxDate={maxDate.toISOString()}
         headerStyle={{ height: 94, marginBottom: 0, marginTop: -5 }}
         renderArrow={(direction) => (
           <Image
@@ -38,6 +42,12 @@ export const ClientCalendar = observer(function CgCalendar(props: ClientCalendar
         dayComponent={({ date, state }) => (
           <ClientCalendarDay
             onPress={() => {
+              // 최대 날짜 초과시, 선택 불가
+              if (isAfter(parseISO(date.dateString), addDays(maxDate, 1))) {
+                alertModal("날짜 선택 범위 초과", "최대 60일 이내 날짜만 선택 가능합니다.")
+                return
+              }
+
               onDayPressProp(date)
             }}
             date={date}


### PR DESCRIPTION
# What is this PR? | PR 설명 🔍
- 참고: https://discord.com/channels/1137734002258755654/1211560421543247922
- PG 사 심사 피드백에 의거하여, 검색 스크린에서 선택 가능한 날짜를 현재 날짜로 부터 60일 이내로 제한했습니다.
  
# Changes | 핵심 변경사항 📝
- ClientCalendar 에 maxDate 을 추가로 설정했습니다.

# Screenshots | 스크린샷 📷
- 없음

# Help me | 도와주세요 🤦🏻‍♂️
- 60일 초과하는 월 (month) 은 보여지지 않도록 해야 함.
- 지금은 보여지긴 하지만, 날짜 (day) 는 선택 불가능 함.
