### PR TITLE
Fix: (카카오 로그인) 이메일 정보 사용에 동의하지 않을 시, unlink 후 안내용 alert 표출

### DIFF
--- a/app/screens/_COMMON/login/kakao-login.ts
+++ b/app/screens/_COMMON/login/kakao-login.ts
@@ -4,6 +4,7 @@ import {
   KakaoOAuthToken,
   KakaoProfile,
   logout,
+  unlink,
 } from "@react-native-seoul/kakao-login"
 import { checkUserExists } from "#api"
 import { alertModal } from "../../../utils/alert-modal"
@@ -82,12 +83,19 @@ const getKakaoProfile = async (logoutHandler): Promise<GetKakaoProfileResult> =>
     const profile: KakaoProfile = await getProfile()
 
     if (!profile) {
-      alertModal("카카오 프로필 가져오기 실패", "profile is false, null or undefined.")
+      alertModal(
+        "카카오 프로필 가져오기 실패",
+        "프로필 정보가 없습니다. 잠시 후, 다시 시도해주세요.",
+      )
       return { isSuccess: false }
     }
 
     if (!profile.email) {
-      alertModal("카카오 프로필 가져오기 실패", "이메일 정보가 존재하지 않습니다.")
+      alertModal(
+        "카카오 프로필 가져오기 실패",
+        "이메일 정보가 존재하지 않습니다. 이메일 정보 사용에 동의해주세요.",
+      )
+      unlinkKakao()
       return { isSuccess: false }
     }
 
@@ -162,5 +170,24 @@ const signOutWithKakao = async (logoutHandler): Promise<void> => {
   } catch (err) {
     logoutHandler()
     console.error("signOut error", err)
+  }
+}
+
+/**
+ * [테스트 결과]
+ * unlink:
+ * - 케어기버 앱과 유저의 카카오로그인 정보 연결을 끊어버림
+ * - unlink 이후 로그인 시도시, 개인정보 [동의하고 계속하기] 버튼부터 처음부터 다시 시작함
+ */
+const unlinkKakao = async (): Promise<boolean> => {
+  try {
+    const res = await unlink()
+    console.log("res", res)
+    // TODO: res 값에 따라, unlink 성공 여부 판단 후, 성공한 경우에만 true 값 반환
+    return true
+  } catch (err) {
+    console.error("unlinkKakao error", err)
+    alertModal("카카오 계정 unlink 실패", `${err?.message}`)
+    return false
   }
 }


### PR DESCRIPTION
# What is this PR? | PR 설명 🔍
- 참고: https://discord.com/channels/1137734002258755654/1211602724924166175/1213325004159324181
- 유저가 카카오 로그인으로 회원가입 시, "이메일 정보 사용"에 동의하지 않을 경우, 이메일 정보를 불러 올 수 없으므로 정상적인 로그인 처리가 불가능 합니다.
- 이를 핸들링하기 위해, 이메일 정보가 없을시 해당 유저를 unlink 하고, 이에 맞는 안내용 alert 메시지를 추가하였습니다.
- 참고(unlink): https://developers.kakao.com/docs/latest/en/kakaologin/common#unlink
 
# Changes | 핵심 변경사항 📝
- 카카오 로그인시 예외 처리 케이스 - "이메일 정보가 없는 경우"가 추가됨

# Screenshots | 스크린샷 📷

| "이메일 사용 동의" 체크 안 함 | 에러 메시지 표출 |
|--------|--------|
| ![image](https://github.com/Care-Giver/CareGiver/assets/70505699/7733f8a8-895a-45c8-b4f4-4b4320b6c96a) | ![image](https://github.com/Care-Giver/CareGiver/assets/70505699/02b09d0d-0efa-44cd-89b4-caecd7e6aa8a) |

# Help me | 도와주세요 🤦🏻‍♂️
**TODO**
- 어쩌면 네이버 로그인에서도 비슷한 작업이 필요할 수도 있음.
- 카카오계정 biz 프로필 전환 후, 이메일 사용 동의를 [필수] 항목으로 변경하도록 해야 함 - @matmang 
