### PR TITLE
Fix: Xcode 15

### DIFF
--- a/ios/CareGiver.xcodeproj/project.pbxproj
+++ b/ios/CareGiver.xcodeproj/project.pbxproj
@@ -509,7 +509,11 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -575,7 +579,11 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;


### PR DESCRIPTION
# What is this PR? | PR 설명 🔍
- 2024년 4월부터 Apple App Store 에 앱을 배포하기 위해서는, iOS 17 을 대상으로 빌드해야 합니다.
   - 참고: https://developer.apple.com/kr/news/upcoming-requirements/?id=04292024a
- iOS 17 빌드를 진행하기 위해서는, Xcode 15 업데이트가 필수 사항이 되었습니다. 
- 따라서, Xcode 15 업데이트를 진행하였습니다. 이후, 케어기버 xcode project 파일에도 변경사항이 생겼습니다.
  
# Changes | 핵심 변경사항 📝
**Xcode 15 업데이트 방법:**
1. MacOS 를 Sonoma 로 업그레이드 합니다.
2. AppStore 에서 Xcode 를 업데이트 합니다.

# Screenshots | 스크린샷 📷
- 없음

# Help me | 도와주세요 🤦🏻‍♂️
- 없음
