### PR TITLE
⚡️Mvp 92: iOS Metro 오류 해결 (shell script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,56 @@
-# 케어기버 프론트 앱 개발 가이드 - v2024-03-05 (최수민 작성)
+케어기버 프론트 앱 개발 가이드 - v2024-03-16 (최수민 작성)
 
 ![CG 헤더](https://cdn.myportfolio.com/dd18ab34-b0c4-483d-8da5-b3f0b4e33fa4/d4362c69-bc87-4a9e-9969-6ca662882061_rwc_16x0x1886x728x4096.png?h=90d6074126a6c3b537cae45b61fbf85a "CG 헤더")
 
----
-
-## 개발환경
+# 개발환경
 
 - node `v18.17.0`
 - npm `9.6.7`
 - cocoapods `1.14.3`
 
-## 주의사항
+# 주의사항
 
-- 패키지 설치 또는 추가시, `npm` 대신 _`yarn` 을 사용주세요_
+- 라이브러리 설치 또는 추가시, `npm` 대신 _`yarn` 을 사용주세요_
 
-## 📱 앱 실행 (디버그 빌드)
+# 📱앱 실행 방법 (디버그 빌드)
 
-`yarn install` 이후:
+(`yarn install` 이후)
 
-### iOS
+## iOS: `yarn ios`
 
-`yarn ios`
+## Android: `yarn android`
 
-### Android
+# 작업 관련 명령어
 
-`yarn android`
+- 컴포넌트 생성: `yarn component 컴포넌트명`
+- 스크린 생성: `yarn screen 스크린명`
+- 모델 생성: `yarn model 모델명`
 
-## 🛠️ 디버그 빌드에서 문제 상황 발생시, 해결 방법 | Troubleshooting
+# 기타 명령어
 
-### Metro 서버가 끊긴 경우:
+- 캐시 삭제(yarn, metro, ios, android): `yarn c `
+- ios 빌드 캐시 삭제: `yarn c:i `
+- android 빌드 캐시 삭제: `yarn c:a`
 
-`yarn start`
+# 🛠️디버그 빌드에서 문제 상황 발생시, 해결 방법 | Troubleshooting
 
-### 8081 포트가 이미 사용중인 경우:
+## 1. 빌드 에러가 발생한 경우 (... BUILD FAILED)
 
-`kill $(lsof -ti:8081)`
+### iOS: `yarn c && yarn c:i && yarn ios`
 
-### pod install 실패시:
+### Android: `yarn c && yarn c:a && yarn android`
+
+<br/>
+
+## 2. Metro 서버가 끊긴 경우: `yarn start`
+
+<br/>
+
+## 3. `8081` 포트가 이미 사용중인 경우: `kill $(lsof -ti:8081)`
+
+<br/>
+
+## 4. `pod install` 실패시:
 
 ```shell
 The Swift pod `ExpoModulesCore` depends upon `React-RCTAppDelegate`, which does not define modules.
@@ -54,7 +68,7 @@ The Swift pod `ExpoModulesCore` depends upon `React-RCTAppDelegate`, which does 
 - ~~다시, `pod install` 시도 하면 정상적으로 성공한다.~~
 - ~~만약 그래도 실패한다면 `rm -rf ~/Library/Developer/Xcode/DerivedData` 이후 다시 `pod install` 해볼 것.~~
 
-#### 위 에러는 `Podfile` 에 다음과 같은 코드를 추가하여 해결 하였습니다. (2023. 12. 25 , @smnchoi)
+## 위 에러는 `Podfile` 에 다음과 같은 코드를 추가하여 해결 하였습니다. (2023. 12. 25 , @smnchoi)
 
 ```ruby
 ...
@@ -73,30 +87,20 @@ pod 'ExpoModulesCore', :path => '../node_modules/expo-modules-core', :modular_he
   이렇게 추가해주면, `multiple dependencies with different sources` 에러가 발생합니다.
 - 이를 방지하기 위해, **`path`를 꼭 명시해줘야 합니다.**
 
-## 작업 관련 명령어
-
-- 컴포넌트 생성: `yarn component 컴포넌트명`
-- 스크린 생성: `yarn screen 스크린명`
-- 모델 생성: `yarn model 모델명`
-
-## 기타 명령어
-
-- 캐시 삭제: `yarn c `
-
 <br/>
 <br/>
 <br/>
 
-# 🛠️ 배포 관련 문제 상황 해결법
+# 🛠️배포 관련 문제 상황 해결법
 
-### 카카오 로그인 Android 오류 해결 (Feat. Upload Key and Signing Key)
+## 카카오 로그인 Android 오류 해결 (Feat. Upload Key and Signing Key)
 
-#### 문제 상황
+### 문제 상황
 
 - debug 빌드 에서는 정상적으로 작동하던 카카오 로그인이, release 빌드에서는 작동하지 않음.
 - `invalid android_key_hash or ios_bundle_id or web_site_url`
 
-#### 원인 및 해결 방법
+### 원인 및 해결 방법
 
 - `Kakao Developers > 내 애플리케이션 > 앱 설정 > 플랫폼` 에서, Android 의 "키 해시" 목록에 "release" 빌드 용 해시키가 존재하지 않았음.
 - 구글은 **"Signing Key" (앱 서명 키)** 를 "직접" 관리 함. 즉, 내 환경에 있는 것이 아니라 Google Play Console 에서 확인 해야 함.
@@ -104,7 +108,7 @@ pod 'ExpoModulesCore', :path => '../node_modules/expo-modules-core', :modular_he
 - `Google Play Console > 내부 테스트` 를 통해 배포된 release 빌드 에서, 카카오 SDK 는 Upload Key 를 사용해서 키를 대조하는 것이 아니라, 배포 과정중에서 구글이 자체적으로 서명한 Signing Key 를 사용하여 대조하게 되기 때문임.
 - 따라서, 이 Signing Key 를 Base64 인코딩 한 값을 Kakao Developers 대시보드에 등록해주어야 함.
 
-#### 참고 자료
+### 참고 자료
 
 **Signing Key 와 Upload Key**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 케어기버 프론트 앱 개발 가이드 - v230602 (최수민 작성)
+# 케어기버 프론트 앱 개발 가이드 - v2024-03-05 (최수민 작성)
 
 ![CG 헤더](https://cdn.myportfolio.com/dd18ab34-b0c4-483d-8da5-b3f0b4e33fa4/d4362c69-bc87-4a9e-9969-6ca662882061_rwc_16x0x1886x728x4096.png?h=90d6074126a6c3b537cae45b61fbf85a "CG 헤더")
 
@@ -6,25 +6,41 @@
 
 ## 개발환경
 
-- node v18.17.0
-- npm 9.6.7
-- cocoapods 1.14.3
+- node `v18.17.0`
+- npm `9.6.7`
+- cocoapods `1.14.3`
 
 ## 주의사항
 
-- 패키지 설치 또는 추가시, npm 대신 _yarn 을 사용주세요_
+- 패키지 설치 또는 추가시, `npm` 대신 _`yarn` 을 사용주세요_
 
-## 앱 실행 방법 (자동)
+## 📱 앱 실행 (디버그 빌드)
 
-1.  `yarn install`
-2.  `yarn ios` 또는 `yarn android`
-3.  (Metro 서버가 끊긴경우) `yarn start-metro`
+`yarn install` 이후:
 
-## ~~pod install 실패시...~~
+### iOS
 
-### ~~The Swift pod `ExpoModulesCore` depends upon `React-RCTAppDelegate`, which does not define modules.~~
+`yarn ios`
 
-```
+### Android
+
+`yarn android`
+
+## 🛠️ 디버그 빌드에서 문제 상황 발생시, 해결 방법 | Troubleshooting
+
+### Metro 서버가 끊긴 경우:
+
+`yarn start`
+
+### 8081 포트가 이미 사용중인 경우:
+
+`kill $(lsof -ti:8081)`
+
+### pod install 실패시:
+
+```shell
+The Swift pod `ExpoModulesCore` depends upon `React-RCTAppDelegate`, which does not define modules.
+
 ...
 Installing react-native-slider (4.4.2)
 Installing react-native-webview (13.6.3)
@@ -40,7 +56,7 @@ The Swift pod `ExpoModulesCore` depends upon `React-RCTAppDelegate`, which does 
 
 #### 위 에러는 `Podfile` 에 다음과 같은 코드를 추가하여 해결 하였습니다. (2023. 12. 25 , @smnchoi)
 
-```
+```ruby
 ...
 pod 'React-RCTAppDelegate', :path => '../node_modules/react-native/Libraries/AppDelegate' :modular_headers => true
 pod 'ExpoModulesCore', :path => '../node_modules/expo-modules-core', :modular_headers => true
@@ -67,16 +83,20 @@ pod 'ExpoModulesCore', :path => '../node_modules/expo-modules-core', :modular_he
 
 - 캐시 삭제: `yarn c `
 
----
+<br/>
+<br/>
+<br/>
 
-# 카카오 로그인 Android 오류 해결 (Feat. Upload Key and Signing Key)
+# 🛠️ 배포 관련 문제 상황 해결법
 
-## 문제 상황
+### 카카오 로그인 Android 오류 해결 (Feat. Upload Key and Signing Key)
+
+#### 문제 상황
 
 - debug 빌드 에서는 정상적으로 작동하던 카카오 로그인이, release 빌드에서는 작동하지 않음.
 - `invalid android_key_hash or ios_bundle_id or web_site_url`
 
-## 원인 및 해결 방법
+#### 원인 및 해결 방법
 
 - `Kakao Developers > 내 애플리케이션 > 앱 설정 > 플랫폼` 에서, Android 의 "키 해시" 목록에 "release" 빌드 용 해시키가 존재하지 않았음.
 - 구글은 **"Signing Key" (앱 서명 키)** 를 "직접" 관리 함. 즉, 내 환경에 있는 것이 아니라 Google Play Console 에서 확인 해야 함.
@@ -84,16 +104,16 @@ pod 'ExpoModulesCore', :path => '../node_modules/expo-modules-core', :modular_he
 - `Google Play Console > 내부 테스트` 를 통해 배포된 release 빌드 에서, 카카오 SDK 는 Upload Key 를 사용해서 키를 대조하는 것이 아니라, 배포 과정중에서 구글이 자체적으로 서명한 Signing Key 를 사용하여 대조하게 되기 때문임.
 - 따라서, 이 Signing Key 를 Base64 인코딩 한 값을 Kakao Developers 대시보드에 등록해주어야 함.
 
-## 참고 자료
+#### 참고 자료
 
-Signing Key 와 Upload Key
+**Signing Key 와 Upload Key**
 
 - https://github.com/crossplatformkorea/react-native-kakao-login/issues/244
 - https://developer.android.com/studio/publish/app-signing#enroll (이거 한글로 보면 용어가 번역되어 있어서 오히려 더 헷갈림. 걍 영어로 볼 것.)
   > - **App signing key**: The key that is used to sign APKs that are installed on a user's device.
   > - **Upload key**: The key you use to sign the app bundle or APK before you upload it for app [signing with Google Play](https://developer.android.com/studio/publish/app-signing#app-signing-google-play)
 
-Base64 인코딩 방법
+**Base64 인코딩 방법**
 
 - https://devtalk.kakao.com/t/topic/130144/2
 - https://kakao-tam.tistory.com/53

--- a/ios/CareGiver.xcodeproj/project.pbxproj
+++ b/ios/CareGiver.xcodeproj/project.pbxproj
@@ -509,7 +509,11 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -575,7 +579,11 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start-metro": "npx react-native start",
-    "start-expo": "npx expo start --dev-client",
+    "start": "npx react-native start",
+    "start:expo": "npx expo start --dev-client",
     "ios": "npx react-native run-ios & npx react-native start",
     "android": "npx react-native run-android",
     "screen": "npx ignite-cli@7.10.8 g screen",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start-metro": "npx react-native start",
     "start-expo": "npx expo start --dev-client",
-    "ios": "npx react-native run-ios",
+    "ios": "npx react-native run-ios & npx react-native start",
     "android": "npx react-native run-android",
     "screen": "npx ignite-cli@7.10.8 g screen",
     "component": "npx ignite-cli@7.10.8 g component",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "npx react-native start",
     "start:expo": "npx expo start --dev-client",
-    "ios": "npx react-native run-ios & npx react-native start",
+    "ios": "cd ios; pod install && cd ..; npx react-native run-ios & npx react-native start",
     "android": "npx react-native run-android",
     "screen": "npx ignite-cli@7.10.8 g screen",
     "component": "npx ignite-cli@7.10.8 g component",
@@ -30,6 +30,8 @@
     "clean-all": "npx react-native clean-project-auto",
     "clear-cache": "npx react-native clean --include android,cocoapods,metro,watchman,yarn",
     "c": "npx react-native clean --include android,cocoapods,metro,watchman,yarn",
+    "c:i": "rm -rf ~/Library/Developer/Xcode/DerivedData && rm -rf ios/build",
+    "c:a": "cd android/; ./gradlew clean; cd ..",
     "eject": "expo eject"
   },
   "dependencies": {


### PR DESCRIPTION
# 🔍 What is this PR for? | PR 설명

> PR 을 만들게 된 원인 / 문제상황 / 해결법 등을 설명해주세요.

- `yarn ios` 실행시, ios 빌드에는 성공하지만, Metro 가 자동으로 켜지지 않는 문제가 있었습니다.
- 원인을 파악하고자 했으나, 핵심 원인은 파악하지 못했습니다.
- 대신, `package.json` 내의 shell script 를 수정하여, Metro 가 실행되도록 `yarn ios` 명령어를 수정했습니다.
- 기본적으로 이 방법은 Concurrency 를 사용합니다. 경우에 따라, Metro 가 여전히 실행되지 않을 수 있습니다.
- 그럴때는, `yarn start` 명령어로 Metro 를 수동으로 실행시킨 뒤에, iOS 앱 내에서 Reload 버튼을 클릭해주세요.

# 📝 Changes | 핵심 변경사항

> 리뷰어가 알아야 할 핵심 변경사항이 있다면 미리 말해주세요.

- 📝명령어 재명명:
   - `yarn start-metro` ➡️ `yarn start`
   - `yarn start-expo` ➡️ `yarn start:expo`
- ➕명령어 추가: 
   -  `yarn c:i` (ios 빌드 캐시 삭제)
   - `yarn c:a` (android 빌드 캐시 삭제)
