### PR TITLE
Feat/카카오페이 실명 추가 및 테스트 결제와 실 결제 분리

### DIFF
--- a/app/models/user-store/user-store.ts
+++ b/app/models/user-store/user-store.ts
@@ -69,6 +69,7 @@ export const UserStoreModel = types
       pushToken: "",
       nicknameLastUpdated: "",
       clientStreamToken: "",
+      realName: "",
     }),
 
     /* 인증된 펫시터인지 여부 */
@@ -255,6 +256,7 @@ export const UserStoreModel = types
           pushToken: pushToken,
           nicknameLastUpdated: userDetail.nicknameLastUpdated,
           clientStreamToken: userDetail.clientStreamToken,
+          realName: userDetail.realName,
         })
 
         return true

--- a/app/screens/_CLIENT/pay-stack/payment/payment-screen.tsx
+++ b/app/screens/_CLIENT/pay-stack/payment/payment-screen.tsx
@@ -54,9 +54,9 @@ export const PaymentScreen: FC<StackScreenProps<NavigatorParamList, "payment-scr
     const [cardQuota, setCardQuota] = useState(0)
     const [merchantUid, setMerchantUid] = useState(`mid_${new Date().getTime()}`)
     const [name, setName] = useState("케어기버:펫시팅 예약")
-    const [buyerName, setBuyerName] = useState(userDetail.realName)
-    const [buyerTel, setBuyerTel] = useState(userDetail.phoneNumber)
-    const [buyerEmail, setBuyerEmail] = useState(userAuth.email)
+    const [buyerName, setBuyerName] = useState(__DEV__ ? "홍길동" : userDetail.realName)
+    const [buyerTel, setBuyerTel] = useState(__DEV__ ? "01000000000" : userDetail.phoneNumber)
+    const [buyerEmail, setBuyerEmail] = useState(__DEV__ ? "dev@caregiver.pet" : userAuth.email)
     const [vbankDue, setVbankDue] = useState("")
     const [bizNum, setBizNum] = useState("")
     const [escrow, setEscrow] = useState(false)
@@ -95,7 +95,7 @@ export const PaymentScreen: FC<StackScreenProps<NavigatorParamList, "payment-scr
       // 2-1. 결제 진행 - 포트원 SDK
       const data: PaymentParams = {
         params: {
-          pg: "kakaopay",
+          pg: `kakaopay.${__DEV__ ? Config.IMP_KAKAOPAY_CID_DEV : Config.IMP_KAKAOPAY_CID}`,
           pay_method: "kakaopay",
           merchant_uid: payment.merchant_uid,
           name,

--- a/app/screens/_CLIENT/pay-stack/payment/payment-screen.tsx
+++ b/app/screens/_CLIENT/pay-stack/payment/payment-screen.tsx
@@ -43,7 +43,7 @@ export const PaymentScreen: FC<StackScreenProps<NavigatorParamList, "payment-scr
     const { key, service, selectedPetIds, selectedTime, bookingRequest, destination } = route.params
     console.log("bookingRequest", bookingRequest)
     const {
-      userStore: { userDetail },
+      userStore: { userDetail, userAuth },
       petStore: { getPetsByIds },
     } = useStores()
 
@@ -54,9 +54,9 @@ export const PaymentScreen: FC<StackScreenProps<NavigatorParamList, "payment-scr
     const [cardQuota, setCardQuota] = useState(0)
     const [merchantUid, setMerchantUid] = useState(`mid_${new Date().getTime()}`)
     const [name, setName] = useState("케어기버:펫시팅 예약")
-    const [buyerName, setBuyerName] = useState("케어기버")
-    const [buyerTel, setBuyerTel] = useState("050-6667-1542")
-    const [buyerEmail, setBuyerEmail] = useState("dev@caregiver.pet")
+    const [buyerName, setBuyerName] = useState(userDetail.realName)
+    const [buyerTel, setBuyerTel] = useState(userDetail.phoneNumber)
+    const [buyerEmail, setBuyerEmail] = useState(userAuth.email)
     const [vbankDue, setVbankDue] = useState("")
     const [bizNum, setBizNum] = useState("")
     const [escrow, setEscrow] = useState(false)

--- a/app/services/api/user.ts
+++ b/app/services/api/user.ts
@@ -32,6 +32,7 @@ interface UserColumns {
   privacyPolicyConsent: boolean // true,
   termsOfServiceConsent: boolean // true,
   nicknameLastUpdated: string //"2023-10-28T00:00:00"
+  realName: string // 포트원 카카오페이 결제 시 필요한 "실명" 정보
 }
 
 export type User = Omit<UserColumns, "createAt" | "updatedAt">
@@ -230,6 +231,7 @@ export type UserDetail = Pick<
   | "pushToken"
   | "nicknameLastUpdated"
   | "clientStreamToken"
+  | "realName"
 >
 
 interface GetMeResult {
@@ -279,6 +281,7 @@ export const getMe = async (token: string): Promise<GetMeResult> => {
         pushToken: response.data.user.pushToken,
         nicknameLastUpdated: response.data.user.nicknameLastUpdated,
         clientStreamToken: response.data.user?.clientStreamToken,
+        realName: response.data.user?.realName,
       },
     }
   } catch (error) {

--- a/react-native-config.d.ts
+++ b/react-native-config.d.ts
@@ -11,6 +11,7 @@ declare module "react-native-config" {
     NAVER_CONSUMER_SECRET: string
     STREAM_CHAT_API_KEY: string
     IMP_KAKAOPAY_CID: string
+    IMP_KAKAOPAY_CID_DEV: string
     IMP_M_REDIRECT_URL: string
   }
 


### PR DESCRIPTION
# 🔍 What is this PR for? | PR 설명

> PR 을 만들게 된 원인 / 문제상황 / 해결법 등을 설명해주세요.

- 카카오페이 CID 값을 앱 빌드 상태에 따라 분기하였습니다.
- 개발용 빌드에는 테스트결제 창이 표출되고, 
- 프로덕션 빌드에는 실제결제 창이 표출됩니다.
- 테스트 결제 시에는 구매자 정보가
   - 홍길동, 01000000000, dev@caregiver.pet 으로 일정하고,
- 실제 결제 시에는 
   - 실명정보를 포함한 유저의 실제 정보로 구매자 정보가 기입됩니다.

# 📝 Changes | 핵심 변경사항

> 리뷰어가 알아야 할 핵심 변경사항이 있다면 미리 말해주세요.

- `__DEV__` 는 RN 에서 사용되는 **전역변수** 입니다.
- Metro 를 사용하고 있는, 즉 디버그용 빌드 일 경우, `__DEV__=true` 입니다.

# 📷 Screenshots | 스크린샷

> PR 을 설명할 스크린샷을 첨부할 수 있다면, 첨부해주세요.

-
| 테스트 결제 (DEV) | 실제 결제 (PROD) |
| --- | --- |
| ![image](https://github.com/Care-Giver/CareGiver/assets/70505699/ed7900d1-b186-4c71-bd35-65317ca13b14) | ![image](https://github.com/Care-Giver/CareGiver/assets/70505699/aea837c4-9cb1-4ace-85dc-eecd45cedc85) |

# TODO

- 애플 심사 제출 시에는, 테스트 결제로 고정하여 제출 할 것.
